### PR TITLE
Allow label param to be html

### DIFF
--- a/src/LexiconButton.js
+++ b/src/LexiconButton.js
@@ -58,14 +58,13 @@ LexiconButton.STATE = {
 
 	/**
 	 * Label of the button
-	 * @default ''
+	 * @default undefined
 	 * @instance
 	 * @memberof LexiconButton
 	 * @type {string}
 	 */
 	label: {
-		validator: core.isString,
-		value: ''
+		isHtml: true
 	},
 
 	/**

--- a/test/LexiconButton.js
+++ b/test/LexiconButton.js
@@ -73,4 +73,12 @@ describe('LexiconButton', () => {
 
 		assert.strictEqual(lexiconButton.element.outerHTML, __html__['test/fixture/testSizeLexiconButton.html']);
 	});
+
+	it('should allow label to be html', () => {
+		lexiconButton = new LexiconButton({
+			label: '<span>Label</span>'
+		});
+
+		assert.strictEqual(lexiconButton.element.outerHTML, __html__['test/fixture/testLabelHtmlLexiconButton.html']);
+	});
 });

--- a/test/fixture/testLabelHtmlLexiconButton.html
+++ b/test/fixture/testLabelHtmlLexiconButton.html
@@ -1,0 +1,1 @@
+<button class="btn btn-default" type="button"><span>Label</span></button>


### PR DESCRIPTION
When implement LexiconButton in LexiconDropdown I ran into this limitation. It currently uses `<span class="icon-caret-down"></span>` as part of the trigger label.